### PR TITLE
Issue to use aiofiles installed via PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+pyvenv/
 build/
 develop-eggs/
 dist/
@@ -55,3 +56,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IDEA IDE files
+.idea/
+*.iml

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Topic :: System :: Filesystems",
     ],
     extras_require={
         ':python_version == "3.3"': ['asyncio', 'singledispatch']

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import codecs
 import os
 import re
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open('README.rst') as f:
     readme = f.read()
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 setup(
     name='aiofiles',
     version=find_version('aiofiles', '__init__.py'),
-    packages=['aiofiles'],
+    packages=find_packages(),
     url='',
     license='Apache 2.0',
     author='Tin Tvrtkovic',


### PR DESCRIPTION
Hi,

In wheel package provided on PyPI, `threadpool` folder is missing.
I've improved your `setup.py` file to avoid that in the future, in case of you add others folders.

If you could release a new version after the merge, it will be useful for everybody ;-)

BTW, thank you for this library.

Regards.