### PR TITLE
make _sync_open monkeypatchable

### DIFF
--- a/aiofiles/threadpool/__init__.py
+++ b/aiofiles/threadpool/__init__.py
@@ -1,5 +1,6 @@
 """Handle files using a thread pool executor."""
 import asyncio
+import builtins
 
 from io import (FileIO, TextIOBase, BufferedReader, BufferedWriter,
                 BufferedRandom)
@@ -9,8 +10,6 @@ from .binary import AsyncBufferedIOBase, AsyncBufferedReader, AsyncFileIO
 from .text import AsyncTextIOWrapper
 from ..base import AiofilesContextManager
 from .._compat import singledispatch, PY_35
-
-_sync_open = open
 
 __all__ = ('open', )
 
@@ -30,7 +29,7 @@ def _open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None
     """Open an asyncio file."""
     if loop is None:
         loop = asyncio.get_event_loop()
-    cb = partial(_sync_open, file, mode=mode, buffering=buffering,
+    cb = partial(builtins.open, file, mode=mode, buffering=buffering,
                  encoding=encoding, errors=errors, newline=newline,
                  closefd=closefd, opener=opener)
     f = yield from loop.run_in_executor(executor, cb)

--- a/tests/threadpool/test_concurrency.py
+++ b/tests/threadpool/test_concurrency.py
@@ -4,6 +4,7 @@ from os.path import join
 import time
 import asyncio
 import pytest
+import builtins
 
 import aiofiles.threadpool
 
@@ -15,11 +16,13 @@ def test_slow_file(monkeypatch, unused_tcp_port):
     with open(filename, mode='rb') as f:
         contents = f.read()
 
+    old_open = open
+
     def new_open(*args, **kwargs):
         time.sleep(1)
-        return open(*args, **kwargs)
+        return old_open(*args, **kwargs)
 
-    monkeypatch.setattr(aiofiles.threadpool, '_sync_open', value=new_open)
+    monkeypatch.setattr(builtins, 'open', value=new_open)
 
     @asyncio.coroutine
     def serve_file(_, writer):

--- a/tests/threadpool/test_open.py
+++ b/tests/threadpool/test_open.py
@@ -1,6 +1,8 @@
 """Test the open functionality."""
 from aiofiles.threadpool import open as aioopen, wrap
 import pytest
+import io
+from unittest.mock import patch, MagicMock
 
 
 @pytest.mark.asyncio
@@ -30,3 +32,12 @@ def test_unsupported_wrap():
     """A type error should be raised when wrapping something unsupported."""
     with pytest.raises(TypeError):
         wrap(int)
+
+
+@pytest.mark.asyncio
+def test_builtins_monkeypatch():
+    mock_open = MagicMock(return_value=io.TextIOBase(io.StringIO()))
+    with patch('builtins.open', mock_open):
+        yield from aioopen('foo')
+
+        assert mock_open.call_count == 1


### PR DESCRIPTION
This replaces the `_sync_open` reference to `open` in `threadpool` to a direct reference to `builtins.open`.

This fixes the situation described in #16.