### PR TITLE
Changed the sendfile test to be more accepting

### DIFF
--- a/aiofiles/os.py
+++ b/aiofiles/os.py
@@ -14,7 +14,7 @@ def stat(path, *, dir_fd=None, follow_symlinks=True, loop=None, executor=None):
     return loop.run_in_executor(executor, fun)
 
 
-if 'posix' in sys.builtin_module_names:
+if hasattr(os, "sendfile"):
     @asyncio.coroutine
     @wraps(os.sendfile)
     def sendfile(out, in_fd, offset, nbytes, *, loop=None, executor=None):


### PR DESCRIPTION
Make `sendfile` more lenient for posix systems that don't have `sendfile` in the `os` module.
This should still achieve the same as the original line on platforms such as windows because windows will not have `sendfile` as an attribute of `os`.