### PR TITLE
threadpool: rename _sync_open to sync_open

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,27 @@ mind ``readline`` doesn't strip newline characters.
     finally:
         yield from f.close()
 
+Writing tests for aiofiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Real file IO can be mocked by patching `aiofiles.threadpool.sync_open`
+as desired. The return type also needs to be registered with the
+`aiofiles.threadpool.wrap` dispatcher:
+
+.. code-block:: python
+
+    threadpool.wrap.register(mock.MagicMock)(
+        lambda *args, **kwargs: threadpool.AsyncBufferedIOBase(*args, **kwargs))
+
+    async def test_stuff():
+        data = 'data'
+        mock_file = mock.MagicMock()
+
+        with mock.patch('aiofiles.threadpool.sync_open', return_value=mock_file) as mock_open:
+            async with aiofiles.open('filename', 'w') as f:
+                await f.write(data)
+
+            mock_file.write.assert_called_once_with(data)
 
 History
 ~~~~~~~

--- a/aiofiles/threadpool/__init__.py
+++ b/aiofiles/threadpool/__init__.py
@@ -10,7 +10,7 @@ from .text import AsyncTextIOWrapper
 from ..base import AiofilesContextManager
 from .._compat import singledispatch, PY_35
 
-_sync_open = open
+sync_open = open
 
 __all__ = ('open', )
 
@@ -30,7 +30,7 @@ def _open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None
     """Open an asyncio file."""
     if loop is None:
         loop = asyncio.get_event_loop()
-    cb = partial(_sync_open, file, mode=mode, buffering=buffering,
+    cb = partial(sync_open, file, mode=mode, buffering=buffering,
                  encoding=encoding, errors=errors, newline=newline,
                  closefd=closefd, opener=opener)
     f = yield from loop.run_in_executor(executor, cb)
@@ -62,4 +62,3 @@ def _(file, *, loop=None, executor=None):
 @wrap.register(FileIO)
 def _(file, *, loop=None, executor=None):
     return AsyncFileIO(file, loop, executor)
-

--- a/tests/threadpool/test_concurrency.py
+++ b/tests/threadpool/test_concurrency.py
@@ -19,7 +19,7 @@ def test_slow_file(monkeypatch, unused_tcp_port):
         time.sleep(1)
         return open(*args, **kwargs)
 
-    monkeypatch.setattr(aiofiles.threadpool, '_sync_open', value=new_open)
+    monkeypatch.setattr(aiofiles.threadpool, 'sync_open', value=new_open)
 
     @asyncio.coroutine
     def serve_file(_, writer):


### PR DESCRIPTION
This also adds documentation and a minimal example for mocking real file IO in tests.