### PR TITLE
Make sendfile_file test conditional

### DIFF
--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -3,6 +3,7 @@ import aiofiles.os
 import asyncio
 from os.path import join, dirname
 import pytest
+import platform
 
 
 @pytest.mark.asyncio
@@ -15,6 +16,8 @@ def test_stat():
     assert stat_res.st_size == 10
 
 
+@pytest.mark.skipif('2.4' < platform.release() < '2.6.33',
+                    reason = "sendfile() syscall doesn't allow file->file")
 @pytest.mark.asyncio
 def test_sendfile_file(tmpdir):
     """Test the sendfile functionality, file-to-file."""


### PR DESCRIPTION
For certain kernel versions, the test fails with OSError: [EINVAL]

According to man(2) sendfile:

In Linux 2.4 and earlier, out_fd could also refer to a regular file; this
possibility went away in the Linux 2.6.x kernel series, but was restored in
Linux 2.6.33

This patch skips the test sendfile_file on kernel versions which fall in the
above range

Fixes #23 