### PR TITLE
remove readable from delegate_to_executor

### DIFF
--- a/aiofiles/threadpool/text.py
+++ b/aiofiles/threadpool/text.py
@@ -4,8 +4,8 @@ from ..base import AsyncBase
 from .._compat import PY_35
 
 
-@delegate_to_executor('close', 'flush', 'isatty', 'read', 'readable',
-                      'readline', 'readlines', 'seek', 'seekable', 'tell',
+@delegate_to_executor('close', 'flush', 'isatty', 'read', 'readline',
+                      'readlines', 'seek', 'seekable', 'tell',
                       'truncate', 'write', 'writable', 'writelines')
 @proxy_method_directly('detach', 'fileno', 'readable')
 @proxy_property_directly('buffer', 'closed', 'encoding', 'errors',


### PR DESCRIPTION
The AsyncTextIOWrapper has the attribute 'readable' in both the delegate_to_executor and the proxy_method_directly decorators. This causes the readable() method to be overwritten with a coroutine and creates a difference in behaviour between AsyncTextIOWrapper and the other async wrappers.

```python
# open with TextIOBase
async with aiofiles.open('file.txt', 'r') as async_fo:
    # expect coroutine
    can_read = await async_fo.readable()

# open with BufferedReader
async with aiofiles.open('file.txt', 'rb') as async_fo:
    # expect function
    can_read = async_fo.readable()
```

Changes proposed remove 'readable' from delegate_to_executor decorator.