### PR TITLE
Aiotemp dev

### DIFF
--- a/aiofiles/__init__.py
+++ b/aiofiles/__init__.py
@@ -1,6 +1,7 @@
 """Utilities for asyncio-friendly file handling."""
 from .threadpool import open
+from .aiotempfile import NamedAioTemporaryFile, AioTemporaryFile
 
 __version__ = '0.3.2'
 
-__all__ = (open, )
+__all__ = (open, NamedAioTemporaryFile, AioTemporaryFile)

--- a/aiofiles/__init__.py
+++ b/aiofiles/__init__.py
@@ -1,7 +1,7 @@
 """Utilities for asyncio-friendly file handling."""
 from .threadpool import open
 from .aiotempfile import NamedAioTemporaryFile, AioTemporaryFile
-
+from .wrap import wrap
 __version__ = '0.3.2'
 
-__all__ = (open, NamedAioTemporaryFile, AioTemporaryFile)
+__all__ = (open, NamedAioTemporaryFile, AioTemporaryFile, wrap)

--- a/aiofiles/aiotempfile.py
+++ b/aiofiles/aiotempfile.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from .base import AiofilesContextManager
+from functools import partial
+from tempfile import NamedTemporaryFile, TemporaryFile
+from .threadpool.binary import AsyncFileIO
+import asyncio
+
+
+def AioTemporaryFile(mode='w+b', buffering=-1, encoding=None,
+                      newline=None, suffix=None, prefix=None,
+                      dir=None, ):
+    return AiofilesContextManager(_wrap(TemporaryFile, loop=None, executor=None, mode=mode,
+                 buffering=buffering, encoding=encoding,
+                      newline=newline, suffix=suffix, prefix=prefix,
+                      dir=dir))
+
+
+def NamedAioTemporaryFile(mode='w+b', buffering=-1, encoding=None,
+                      newline=None, suffix=None, prefix=None,
+                      dir=None, delete=True):
+    return AiofilesContextManager(_wrap(NamedTemporaryFile, loop=None, executor=None, mode=mode,
+                 buffering=buffering, encoding=encoding,
+                      newline=newline, suffix=suffix, prefix=prefix,
+                      dir=dir,  delete=delete))
+
+
+def _wrap(callable, loop=None, executor=None, *args, **kargs):
+    if loop is None:
+        loop = asyncio.get_event_loop()
+    cb = partial(callable, *args, **kargs)
+    f = yield from loop.run_in_executor(executor, cb)
+
+    return AsyncFileIO(f, loop=loop, executor=executor)

--- a/aiofiles/threadpool/__init__.py
+++ b/aiofiles/threadpool/__init__.py
@@ -1,14 +1,8 @@
 """Handle files using a thread pool executor."""
 import asyncio
-
-from io import (FileIO, TextIOBase, BufferedReader, BufferedWriter,
-                BufferedRandom)
 from functools import partial
-
-from .binary import AsyncBufferedIOBase, AsyncBufferedReader, AsyncFileIO
-from .text import AsyncTextIOWrapper
 from ..base import AiofilesContextManager
-from .._compat import singledispatch
+from ..wrap import wrap
 
 sync_open = open
 
@@ -36,29 +30,3 @@ def _open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None
     f = yield from loop.run_in_executor(executor, cb)
 
     return wrap(f, loop=loop, executor=executor)
-
-
-@singledispatch
-def wrap(file, *, loop=None, executor=None):
-    raise TypeError('Unsupported io type: {}.'.format(file))
-
-
-@wrap.register(TextIOBase)
-def _(file, *, loop=None, executor=None):
-    return AsyncTextIOWrapper(file, loop=loop, executor=executor)
-
-
-@wrap.register(BufferedWriter)
-def _(file, *, loop=None, executor=None):
-    return AsyncBufferedIOBase(file, loop=loop, executor=executor)
-
-
-@wrap.register(BufferedReader)
-@wrap.register(BufferedRandom)
-def _(file, *, loop=None, executor=None):
-    return AsyncBufferedReader(file, loop=loop, executor=executor)
-
-
-@wrap.register(FileIO)
-def _(file, *, loop=None, executor=None):
-    return AsyncFileIO(file, loop, executor)

--- a/aiofiles/wrap.py
+++ b/aiofiles/wrap.py
@@ -1,0 +1,32 @@
+# -*-coding: utf-8 -*-
+from io import (FileIO, TextIOBase, BufferedReader, BufferedWriter,
+                BufferedRandom)
+from .threadpool.binary import AsyncBufferedIOBase, AsyncBufferedReader, AsyncFileIO
+from .threadpool.text import AsyncTextIOWrapper
+from ._compat import singledispatch
+
+
+@singledispatch
+def wrap(file, *, loop=None, executor=None):
+    raise TypeError('Unsupported io type: {}.'.format(file))
+
+
+@wrap.register(TextIOBase)
+def _(file, *, loop=None, executor=None):
+    return AsyncTextIOWrapper(file, loop=loop, executor=executor)
+
+
+@wrap.register(BufferedWriter)
+def _(file, *, loop=None, executor=None):
+    return AsyncBufferedIOBase(file, loop=loop, executor=executor)
+
+
+@wrap.register(BufferedReader)
+@wrap.register(BufferedRandom)
+def _(file, *, loop=None, executor=None):
+    return AsyncBufferedReader(file, loop=loop, executor=executor)
+
+
+@wrap.register(FileIO)
+def _(file, *, loop=None, executor=None):
+    return AsyncFileIO(file, loop, executor)


### PR DESCRIPTION
Add tempfile API support, now you can access the tempfile like this:
```python
async with AioTemporaryFile("w+") as f:
    await f.write("+++")
    await f.seek(0)
    print(await f.read())
```
And I moved wrap() to a separated file in order to wrap an opened file.