### PR TITLE
Return result instead of Future from os funcs wrapper

### DIFF
--- a/aiofiles/os.py
+++ b/aiofiles/os.py
@@ -5,13 +5,12 @@ import os
 
 
 def wrap(func):
-    @asyncio.coroutine
     @wraps(func)
-    def run(*args, loop=None, executor=None, **kwargs):
+    async def run(*args, loop=None, executor=None, **kwargs):
         if loop is None:
             loop = asyncio.get_event_loop()
         pfunc = partial(func, *args, **kwargs)
-        return loop.run_in_executor(executor, pfunc)
+        return await loop.run_in_executor(executor, pfunc)
 
     return run
 


### PR DESCRIPTION
Since support for python3.4 was dropped from the lib I've tried to change from `yield from` syntax to awaits.

Immediately got into `AttributeError: 'Future' object has no attribute st_size` in `test_os.py::test_stat`. Change is small but in return type, so I decided to show it separately.

And another one: [here](https://github.com/Tinche/aiofiles/blob/master/aiofiles/base.py#L63) `__iter__` has `@asyncio.coroutine`. I don't think it should (and tests pass without it too :) )