### PR TITLE
Async version of functions in os.path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,14 @@ several useful ``os`` functions that deal with files:
 * ``remove``
 * ``mkdir``
 * ``rmdir``
+* ``path.exists``
+* ``path.isfile``
+* ``path.isdir``
+* ``path.getsize``
+* ``path.getatime``
+* ``path.getctime``
+* ``path.samefile``
+* ``path.sameopenfile``
 
 Writing tests for aiofiles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,10 @@ several useful ``os`` functions that deal with files:
 
 * ``stat``
 * ``sendfile``
+* ``rename``
+* ``remove``
+* ``mkdir``
+* ``rmdir``
 
 Writing tests for aiofiles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aiofiles/os.py
+++ b/aiofiles/os.py
@@ -22,7 +22,9 @@ stat = wrap(os.stat)
 rename = wrap(os.rename)
 remove = wrap(os.remove)
 mkdir = wrap(os.mkdir)
+makedirs = wrap(os.makedirs)
 rmdir = wrap(os.rmdir)
+removedirs = wrap(os.removedirs)
 
 if hasattr(os, "sendfile"):
     sendfile = wrap(os.sendfile)

--- a/aiofiles/os.py
+++ b/aiofiles/os.py
@@ -17,7 +17,10 @@ def wrap(func):
 
 
 stat = wrap(os.stat)
+rename = wrap(os.rename)
 remove = wrap(os.remove)
+mkdir = wrap(os.mkdir)
+rmdir = wrap(os.rmdir)
 
 if hasattr(os, "sendfile"):
     sendfile = wrap(os.sendfile)

--- a/aiofiles/os.py
+++ b/aiofiles/os.py
@@ -17,6 +17,7 @@ def wrap(func):
 
 
 stat = wrap(os.stat)
+remove = wrap(os.remove)
 
 if hasattr(os, "sendfile"):
     sendfile = wrap(os.sendfile)

--- a/aiofiles/os.py
+++ b/aiofiles/os.py
@@ -15,6 +15,8 @@ def wrap(func):
 
     return run
 
+from . import ospath as path
+
 
 stat = wrap(os.stat)
 rename = wrap(os.rename)

--- a/aiofiles/ospath.py
+++ b/aiofiles/ospath.py
@@ -1,0 +1,14 @@
+"""Async executor versions of file functions from the os.path module."""
+
+from .os import wrap
+from os import path
+
+exist = wrap(path.exists)
+isfile = wrap(path.isfile)
+isdir = wrap(path.isdir)
+getsize = wrap(path.getsize)
+getmtime = wrap(path.getmtime)
+getatime = wrap(path.getatime)
+getctime = wrap(path.getctime)
+samefile = wrap(path.samefile)
+sameopenfile = wrap(path.sameopenfile)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -118,3 +118,76 @@ def test_sendfile_socket(unused_tcp_port):
 
     yield from server.wait_closed()
 
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_exists():
+    """Test path.exists call."""
+    filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    result = yield from aiofiles.os.path.exist(filename)
+    print(result)
+    assert result
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_isfile():
+    """Test path.isfile call."""
+    filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    result = yield from aiofiles.os.path.isfile(filename)
+    assert result
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_isdir():
+    """Test path.isdir call."""
+    filename = join(dirname(__file__), 'resources')
+    result = yield from aiofiles.os.path.isdir(filename)
+    assert result
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_getsize():
+    """Test path.getsize call."""
+    filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    result = yield from aiofiles.os.path.getsize(filename)
+    assert result == 10
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_samefile():
+    """Test path.samefile call."""
+    filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    result = yield from aiofiles.os.path.samefile(filename, filename)
+    assert result
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_getmtime():
+    """Test path.getmtime call."""
+    filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    result = yield from aiofiles.os.path.getmtime(filename)
+    assert result
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_getatime():
+    """Test path.getatime call."""
+    filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    result = yield from aiofiles.os.path.getatime(filename)
+    assert result
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_getctime():
+    """Test path. call."""
+    filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    result = yield from aiofiles.os.path.getctime(filename)
+    assert result
+

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -167,6 +167,15 @@ def test_samefile():
 
 @asyncio.coroutine
 @pytest.mark.asyncio
+def test_sameopenfile():
+    """Test path.samefile call."""
+    filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    result = yield from aiofiles.os.path.samefile(filename, filename)
+    assert result
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
 def test_getmtime():
     """Test path.getmtime call."""
     filename = join(dirname(__file__), 'resources', 'test_file1.txt')

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -1,7 +1,7 @@
 """Tests for asyncio's os module."""
 import aiofiles.os
 import asyncio
-from os.path import join, dirname
+from os.path import join, dirname, exists
 import pytest
 import platform
 
@@ -16,6 +16,18 @@ def test_stat():
 
     assert stat_res.st_size == 10
 
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_remove():
+    """Test the remove call."""
+    filename = join(dirname(__file__), 'resources', 'test_file2.txt')
+    with open(filename, 'w') as f:
+        f.write('Test file for remove call')
+
+    assert exists(filename)
+    yield from aiofiles.os.remove(filename)
+    assert exists(filename) is False
 
 @asyncio.coroutine
 @pytest.mark.skipif('2.4' < platform.release() < '2.6.33',

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -1,7 +1,7 @@
 """Tests for asyncio's os module."""
 import aiofiles.os
 import asyncio
-from os.path import join, dirname, exists
+from os.path import join, dirname, exists, isdir
 import pytest
 import platform
 
@@ -28,6 +28,30 @@ def test_remove():
     assert exists(filename)
     yield from aiofiles.os.remove(filename)
     assert exists(filename) is False
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_mkdir_and_rmdir():
+    """Test the mkdir and rmdir call."""
+    directory = join(dirname(__file__), 'resources', 'test_dir')
+    yield from aiofiles.os.mkdir(directory)
+    assert isdir(directory)
+    yield from aiofiles.os.rmdir(directory)
+    assert exists(directory) is False
+
+
+@asyncio.coroutine
+@pytest.mark.asyncio
+def test_rename():
+    """Test the rename call."""
+    old_filename = join(dirname(__file__), 'resources', 'test_file1.txt')
+    new_filename = join(dirname(__file__), 'resources', 'test_file2.txt')
+    yield from aiofiles.os.rename(old_filename, new_filename)
+    assert exists(old_filename) is False and exists(new_filename)
+    yield from aiofiles.os.rename(new_filename, old_filename)
+    assert exists(old_filename) and exists(new_filename) is False
+
 
 @asyncio.coroutine
 @pytest.mark.skipif('2.4' < platform.release() < '2.6.33',


### PR DESCRIPTION
I think os.path function would be commonly used. Their corresponding async version is now provided. Functions of `path.exist`, `path.isfile`, `path.isdir`, `path.getsize`, `path.getmtime`, `path.getctime`, `path.getatime`, `path.samefile`, `path.sameopenfile`.

All of these functions are tested.