### PR TITLE
Fix DeprecationWarning removing coro decorator

### DIFF
--- a/aiofiles/os.py
+++ b/aiofiles/os.py
@@ -5,9 +5,8 @@ import os
 
 
 def wrap(func):
-    @asyncio.coroutine
     @wraps(func)
-    def run(*args, loop=None, executor=None, **kwargs):
+    async def run(*args, loop=None, executor=None, **kwargs):
         if loop is None:
             loop = asyncio.get_event_loop()
         pfunc = partial(func, *args, **kwargs)


### PR DESCRIPTION
This commit fixes DeprecationWarning in `os.py` by replacing deprecated
decorator (in Python 3.8+) `@asyncio.coroutine` with `async def`.

Closes #74 .