### PR TITLE
Add repo link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "File support for asyncio."
 authors = ["Tin Tvrtkovic <tinchester@gmail.com>"]
 license = "Apache-2.0"
 readme = "README.rst"
+repository = "https://github.com/Tinche/aiofiles
 
 [tool.poetry.dependencies]
 python = "^3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "File support for asyncio."
 authors = ["Tin Tvrtkovic <tinchester@gmail.com>"]
 license = "Apache-2.0"
 readme = "README.rst"
-repository = "https://github.com/Tinche/aiofiles
+repository = "https://github.com/Tinche/aiofiles"
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
I came across the project via [PyPI](https://pypi.org/project/aiofiles/) and wanted to take a look at the source code.

I notice there's currently no "Project Links" on the project's PyPI page so had to search for the repo separately, which isn't too bad but it's a nice convenience to be able to jump straight from PyPI 😄

It just requires a link to this repo to be included in the `pyproject.toml` file ([docs](https://python-poetry.org/docs/pyproject/#repository)) and then once you push your next release the link to the repo will get added to PyPI 👍 