### PR TITLE
Add aiofiles.os.renames function

### DIFF
--- a/src/aiofiles/os.py
+++ b/src/aiofiles/os.py
@@ -20,6 +20,7 @@ from . import ospath as path
 
 stat = wrap(os.stat)
 rename = wrap(os.rename)
+renames = wrap(os.renames)
 replace = wrap(os.replace)
 remove = wrap(os.remove)
 mkdir = wrap(os.mkdir)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -50,6 +50,23 @@ async def test_rename():
 
 
 @pytest.mark.asyncio
+async def test_renames():
+    """Test the renames call."""
+    old_filename = join(dirname(__file__), "resources", "test_file1.txt")
+    new_filename = join(
+        dirname(__file__), "resources", "subdirectory", "test_file2.txt"
+    )
+    await aiofiles.os.renames(old_filename, new_filename)
+    assert exists(old_filename) is False and exists(new_filename)
+    await aiofiles.os.renames(new_filename, old_filename)
+    assert (
+        exists(old_filename) and
+        exists(new_filename) is False and
+        exists(dirname(new_filename)) is False
+    )
+
+
+@pytest.mark.asyncio
 async def test_replace():
     """Test the replace call."""
     old_filename = join(dirname(__file__), "resources", "test_file1.txt")


### PR DESCRIPTION
The `os` module in the stdlib provides a function called `os.renames` that operates in a very similar way to `os.rename` but will create missing intermediate directories in the new path and delete directories corresponding to rightmost path segments of the old path. This PR adds the async version of that.

Docs: https://docs.python.org/3/library/os.html#os.renames

I've added the relevant unit test in `test_os.py`