### PR TITLE
Move SpooledTemporaryFile.newlines from delegation to property

### DIFF
--- a/src/aiofiles/tempfile/temptypes.py
+++ b/src/aiofiles/tempfile/temptypes.py
@@ -18,7 +18,6 @@ from functools import partial
     "close",
     "flush",
     "isatty",
-    "newlines",
     "read",
     "readline",
     "readlines",
@@ -26,7 +25,7 @@ from functools import partial
     "tell",
     "truncate",
 )
-@proxy_property_directly("closed", "encoding", "mode", "name", "softspace")
+@proxy_property_directly("closed", "encoding", "mode", "name", "newlines", "softspace")
 class AsyncSpooledTemporaryFile(AsyncBase):
     """Async wrapper for SpooledTemporaryFile class"""
 

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -65,6 +65,28 @@ async def test_spooled_temporary_file(mode):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "test_string, newlines", [("LF\n", "\n"), ("CRLF\r\n", "\r\n")]
+)
+async def test_spooled_temporary_file_newlines(test_string, newlines):
+    """
+    Test `newlines` property in spooled temporary file.
+    issue https://github.com/Tinche/aiofiles/issues/118
+    """
+
+    async with tempfile.SpooledTemporaryFile(mode="w+") as f:
+        await f.write(test_string)
+        await f.flush()
+        await f.seek(0)
+
+        assert f.newlines is None
+
+        await f.read()
+
+        assert f.newlines == newlines
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("prefix, suffix", [("a", "b"), ("c", "d"), ("e", "f")])
 async def test_temporary_directory(prefix, suffix, tmp_path):
     """Test temporary directory."""

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -3,6 +3,7 @@ import pytest
 from aiofiles import tempfile
 import os
 import io
+import sys
 
 
 @pytest.mark.asyncio
@@ -65,6 +66,13 @@ async def test_spooled_temporary_file(mode):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason=(
+       "text-mode SpooledTemporaryFile is implemented with StringIO in py3.6"
+       "it doesn't support `newlines`"
+    )
+)
 @pytest.mark.parametrize(
     "test_string, newlines", [("LF\n", "\n"), ("CRLF\r\n", "\r\n")]
 )


### PR DESCRIPTION
Hi!

I found a minor issue in SpooledTemporaryFile and I fixed it.

Fix https://github.com/Tinche/aiofiles/issues/118

ref) https://github.com/python/cpython/blob/3e43fac2503afe219336742b150b3ef6e470686f/Lib/tempfile.py#L747

