### PR TITLE
Add aiofiles.os.symlink function

### DIFF
--- a/src/aiofiles/os.py
+++ b/src/aiofiles/os.py
@@ -28,6 +28,7 @@ makedirs = wrap(os.makedirs)
 rmdir = wrap(os.rmdir)
 removedirs = wrap(os.removedirs)
 link = wrap(os.link)
+symlink = wrap(os.symlink)
 
 if hasattr(os, "sendfile"):
     sendfile = wrap(os.sendfile)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -239,9 +239,8 @@ async def test_link():
         exists(src_filename)
         and exists(dst_filename)
         and (stat(src_filename).st_ino == stat(dst_filename).st_ino)
-        and (stat(src_filename).st_nlink == initial_src_nlink + 1)(
-            stat(dst_filename).st_nlink == 2
-        )
+        and (stat(src_filename).st_nlink == initial_src_nlink + 1)
+        and (stat(dst_filename).st_nlink == 2)
     )
     await aiofiles.os.remove(dst_filename)
     assert (

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -233,12 +233,34 @@ async def test_link():
     """Test the link call."""
     src_filename = join(dirname(__file__), "resources", "test_file1.txt")
     dst_filename = join(dirname(__file__), "resources", "test_file2.txt")
+    initial_src_nlink = stat(src_filename).st_nlink
     await aiofiles.os.link(src_filename, dst_filename)
     assert (
-        exists(src_filename) and
-        exists(dst_filename) and
-        stat(src_filename).st_ino == stat(dst_filename).st_ino
+        exists(src_filename)
+        and exists(dst_filename)
+        and (stat(src_filename).st_ino == stat(dst_filename).st_ino)
+        and (stat(src_filename).st_nlink == initial_src_nlink + 1)(
+            stat(dst_filename).st_nlink == 2
+        )
+    )
+    await aiofiles.os.remove(dst_filename)
+    assert (
+        exists(src_filename)
+        and exists(dst_filename) is False
+        and (stat(src_filename).st_nlink == initial_src_nlink)
+    )
+
+
+@pytest.mark.asyncio
+async def test_symlink():
+    """Test the symlink call."""
+    src_filename = join(dirname(__file__), "resources", "test_file1.txt")
+    dst_filename = join(dirname(__file__), "resources", "test_file2.txt")
+    await aiofiles.os.symlink(src_filename, dst_filename)
+    assert (
+        exists(src_filename)
+        and exists(dst_filename)
+        and stat(src_filename).st_ino == stat(dst_filename).st_ino
     )
     await aiofiles.os.remove(dst_filename)
     assert exists(src_filename) and exists(dst_filename) is False
-


### PR DESCRIPTION
The `os` module in the stdlib provides a function called `os.symlink` that creates a symlink to the src file. This PR adds the async version of that.

Docs: https://docs.python.org/3/library/os.html#os.symlink

I've added the relevant unit test in test_os.py, plus updated the `aiofiles.os.link` test to better differentiate the two.