### PR TITLE
Add aiofiles.os.readlink function

### DIFF
--- a/src/aiofiles/os.py
+++ b/src/aiofiles/os.py
@@ -30,6 +30,7 @@ rmdir = wrap(os.rmdir)
 removedirs = wrap(os.removedirs)
 link = wrap(os.link)
 symlink = wrap(os.symlink)
+readlink = wrap(os.readlink)
 
 if hasattr(os, "sendfile"):
     sendfile = wrap(os.sendfile)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -285,3 +285,4 @@ async def test_readlink():
     await aiofiles.os.symlink(src_filename, dst_filename)
     symlinked_path = await aiofiles.os.readlink(dst_filename)
     assert src_filename == symlinked_path
+    await aiofiles.os.remove(dst_filename)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -275,3 +275,13 @@ async def test_symlink():
     )
     await aiofiles.os.remove(dst_filename)
     assert exists(src_filename) and exists(dst_filename) is False
+
+
+@pytest.mark.asyncio
+async def test_readlink():
+    """Test the readlink call."""
+    src_filename = join(dirname(__file__), "resources", "test_file1.txt")
+    dst_filename = join(dirname(__file__), "resources", "test_file2.txt")
+    await aiofiles.os.symlink(src_filename, dst_filename)
+    symlinked_path = await aiofiles.os.readlink(dst_filename)
+    assert src_filename == symlinked_path


### PR DESCRIPTION
Following up on the symlink PR #124 this PR adds the `aiofiles.os.readlink` function to retrieve the symlinked path from the symlink.

Docs: https://docs.python.org/3/library/os.html#os.readlink

Added a test case.