### PR TITLE
Add async stdio files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,11 @@ and delegate to an executor:
 
 In case of failure, one of the usual exceptions will be raised.
 
+``aiofiles.stdin``, ``aiofiles.stdout``, ``aiofiles.stderr``,
+``aiofiles.stdin_bytes``, ``aiofiles.stdout_bytes``, and
+``aiofiles.stderr_bytes`` provide async access to ``sys.stdin``,
+``sys.stdout``, ``sys.stderr``, and their corresponding ``.buffer`` properties.
+
 The ``aiofiles.os`` module contains executor-enabled coroutine versions of
 several useful ``os`` functions that deal with files:
 

--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,8 @@ History
   `#146 <https://github.com/Tinche/aiofiles/pull/146>`_
 * Removed ``aiofiles.tempfile.temptypes.AsyncSpooledTemporaryFile.softspace``.
   `#151 <https://github.com/Tinche/aiofiles/pull/151>`_
+* Added ``aiofiles.stdin``, ``aiofiles.stdin_bytes``, and other stdio streams.
+  `#154 <https://github.com/Tinche/aiofiles/pull/154>`_
 
 22.1.0 (2022-09-04)
 ```````````````````

--- a/src/aiofiles/__init__.py
+++ b/src/aiofiles/__init__.py
@@ -1,5 +1,22 @@
 """Utilities for asyncio-friendly file handling."""
-from .threadpool import open
+from .threadpool import (
+    open,
+    stdin,
+    stdout,
+    stderr,
+    stdin_bytes,
+    stdout_bytes,
+    stderr_bytes,
+)
 from . import tempfile
 
-__all__ = ["open", "tempfile"]
+__all__ = [
+    "open",
+    "tempfile",
+    "stdin",
+    "stdout",
+    "stderr",
+    "stdin_bytes",
+    "stdout_bytes",
+    "stderr_bytes",
+]

--- a/src/aiofiles/base.py
+++ b/src/aiofiles/base.py
@@ -1,13 +1,18 @@
 """Various base classes."""
 from types import coroutine
 from collections.abc import Coroutine
+from asyncio import get_running_loop
 
 
 class AsyncBase:
     def __init__(self, file, loop, executor):
         self._file = file
-        self._loop = loop
         self._executor = executor
+        self._ref_loop = loop
+
+    @property
+    def _loop(self):
+        return self._ref_loop or get_running_loop()
 
     def __aiter__(self):
         """We are our own iterator."""
@@ -23,6 +28,20 @@ class AsyncBase:
             return line
         else:
             raise StopAsyncIteration
+
+
+class AsyncIndirectBase(AsyncBase):
+    def __init__(self, file, loop, executor, indirect):
+        self._indirect = indirect
+        super().__init__(file, loop, executor)
+
+    @property
+    def _file(self):
+        return self._indirect()
+
+    @_file.setter
+    def _file(self, v):
+        pass  # discard writes
 
 
 class _ContextManager(Coroutine):

--- a/src/aiofiles/base.py
+++ b/src/aiofiles/base.py
@@ -31,9 +31,10 @@ class AsyncBase:
 
 
 class AsyncIndirectBase(AsyncBase):
-    def __init__(self, file, loop, executor, indirect):
+    def __init__(self, name, loop, executor, indirect):
         self._indirect = indirect
-        super().__init__(file, loop, executor)
+        self._name = name
+        super().__init__(None, loop, executor)
 
     @property
     def _file(self):

--- a/src/aiofiles/threadpool/__init__.py
+++ b/src/aiofiles/threadpool/__init__.py
@@ -100,71 +100,35 @@ def _open(
 
 
 @singledispatch
-def wrap(file, *, loop=None, executor=None, indirect=None):
+def wrap(file, *, loop=None, executor=None):
     raise TypeError("Unsupported io type: {}.".format(file))
 
 
 @wrap.register(TextIOBase)
-def _(file, *, loop=None, executor=None, indirect=None):
-    if indirect is None:
-        return AsyncTextIOWrapper(file, loop=loop, executor=executor)
-    else:
-        return AsyncTextIndirectIOWrapper(
-            file, loop=loop, executor=executor, indirect=indirect
-        )
+def _(file, *, loop=None, executor=None):
+    return AsyncTextIOWrapper(file, loop=loop, executor=executor)
 
 
 @wrap.register(BufferedWriter)
 @wrap.register(BufferedIOBase)
-def _(file, *, loop=None, executor=None, indirect=None):
-    if indirect is None:
-        return AsyncBufferedIOBase(file, loop=loop, executor=executor)
-    else:
-        return AsyncIndirectBufferedIOBase(
-            file, loop=loop, executor=executor, indirect=indirect
-        )
+def _(file, *, loop=None, executor=None):
+    return AsyncBufferedIOBase(file, loop=loop, executor=executor)
 
 
 @wrap.register(BufferedReader)
 @wrap.register(BufferedRandom)
-def _(file, *, loop=None, executor=None, indirect=None):
-    if indirect is None:
-        return AsyncBufferedReader(file, loop=loop, executor=executor)
-    else:
-        return AsyncIndirectBufferedReader(
-            file, loop=loop, executor=executor, indirect=indirect
-        )
+def _(file, *, loop=None, executor=None):
+    return AsyncBufferedReader(file, loop=loop, executor=executor)
 
 
 @wrap.register(FileIO)
-def _(file, *, loop=None, executor=None, indirect=None):
-    if indirect is None:
-        return AsyncFileIO(file, loop, executor)
-    else:
-        return AsyncIndirectFileIO(file, loop, executor, indirect=indirect)
+def _(file, *, loop=None, executor=None):
+    return AsyncFileIO(file, loop=loop, executor=executor)
 
 
-try:
-    stdin = wrap(sys.stdin, indirect=lambda: sys.stdin)
-except TypeError:
-    stdin = None
-try:
-    stdout = wrap(sys.stdout, indirect=lambda: sys.stdout)
-except TypeError:
-    stdout = None
-try:
-    stderr = wrap(sys.stderr, indirect=lambda: sys.stderr)
-except TypeError:
-    stdout = None
-try:
-    stdin_bytes = wrap(sys.stdin.buffer, indirect=lambda: sys.stdin.buffer)
-except TypeError:
-    stdin_bytes = None
-try:
-    stdout_bytes = wrap(sys.stdout.buffer, indirect=lambda: sys.stdout.buffer)
-except TypeError:
-    stdout_bytes = None
-try:
-    stderr_bytes = wrap(sys.stderr.buffer, indirect=lambda: sys.stderr.buffer)
-except TypeError:
-    stderr_bytes = None
+stdin = AsyncTextIndirectIOWrapper('sys.stdin', None, None, indirect=lambda: sys.stdin)
+stdout = AsyncTextIndirectIOWrapper('sys.stdout', None, None, indirect=lambda: sys.stdout)
+stderr = AsyncTextIndirectIOWrapper('sys.stderr', None, None, indirect=lambda: sys.stderr)
+stdin_bytes = AsyncIndirectBufferedIOBase('sys.stdin.buffer', None, None, indirect=lambda: sys.stdin.buffer)
+stdout_bytes = AsyncIndirectBufferedIOBase('sys.stdout.buffer', None, None, indirect=lambda: sys.stdout.buffer)
+stderr_bytes = AsyncIndirectBufferedIOBase('sys.stderr.buffer', None, None, indirect=lambda: sys.stderr.buffer)

--- a/src/aiofiles/threadpool/__init__.py
+++ b/src/aiofiles/threadpool/__init__.py
@@ -1,5 +1,6 @@
 """Handle files using a thread pool executor."""
 import asyncio
+import sys
 from types import coroutine
 
 from io import (
@@ -8,16 +9,32 @@ from io import (
     BufferedReader,
     BufferedWriter,
     BufferedRandom,
+    BufferedIOBase,
 )
 from functools import partial, singledispatch
 
-from .binary import AsyncBufferedIOBase, AsyncBufferedReader, AsyncFileIO
-from .text import AsyncTextIOWrapper
+from .binary import (
+    AsyncBufferedIOBase,
+    AsyncBufferedReader,
+    AsyncFileIO,
+    AsyncIndirectBufferedIOBase,
+    AsyncIndirectBufferedReader,
+    AsyncIndirectFileIO,
+)
+from .text import AsyncTextIOWrapper, AsyncTextIndirectIOWrapper
 from ..base import AiofilesContextManager
 
 sync_open = open
 
-__all__ = ("open",)
+__all__ = (
+    "open",
+    "stdin",
+    "stdout",
+    "stderr",
+    "stdin_bytes",
+    "stdout_bytes",
+    "stderr_bytes",
+)
 
 
 def open(
@@ -83,26 +100,71 @@ def _open(
 
 
 @singledispatch
-def wrap(file, *, loop=None, executor=None):
+def wrap(file, *, loop=None, executor=None, indirect=None):
     raise TypeError("Unsupported io type: {}.".format(file))
 
 
 @wrap.register(TextIOBase)
-def _(file, *, loop=None, executor=None):
-    return AsyncTextIOWrapper(file, loop=loop, executor=executor)
+def _(file, *, loop=None, executor=None, indirect=None):
+    if indirect is None:
+        return AsyncTextIOWrapper(file, loop=loop, executor=executor)
+    else:
+        return AsyncTextIndirectIOWrapper(
+            file, loop=loop, executor=executor, indirect=indirect
+        )
 
 
 @wrap.register(BufferedWriter)
-def _(file, *, loop=None, executor=None):
-    return AsyncBufferedIOBase(file, loop=loop, executor=executor)
+@wrap.register(BufferedIOBase)
+def _(file, *, loop=None, executor=None, indirect=None):
+    if indirect is None:
+        return AsyncBufferedIOBase(file, loop=loop, executor=executor)
+    else:
+        return AsyncIndirectBufferedIOBase(
+            file, loop=loop, executor=executor, indirect=indirect
+        )
 
 
 @wrap.register(BufferedReader)
 @wrap.register(BufferedRandom)
-def _(file, *, loop=None, executor=None):
-    return AsyncBufferedReader(file, loop=loop, executor=executor)
+def _(file, *, loop=None, executor=None, indirect=None):
+    if indirect is None:
+        return AsyncBufferedReader(file, loop=loop, executor=executor)
+    else:
+        return AsyncIndirectBufferedReader(
+            file, loop=loop, executor=executor, indirect=indirect
+        )
 
 
 @wrap.register(FileIO)
-def _(file, *, loop=None, executor=None):
-    return AsyncFileIO(file, loop, executor)
+def _(file, *, loop=None, executor=None, indirect=None):
+    if indirect is None:
+        return AsyncFileIO(file, loop, executor)
+    else:
+        return AsyncIndirectFileIO(file, loop, executor, indirect=indirect)
+
+
+try:
+    stdin = wrap(sys.stdin, indirect=lambda: sys.stdin)
+except TypeError:
+    stdin = None
+try:
+    stdout = wrap(sys.stdout, indirect=lambda: sys.stdout)
+except TypeError:
+    stdout = None
+try:
+    stderr = wrap(sys.stderr, indirect=lambda: sys.stderr)
+except TypeError:
+    stdout = None
+try:
+    stdin_bytes = wrap(sys.stdin.buffer, indirect=lambda: sys.stdin.buffer)
+except TypeError:
+    stdin_bytes = None
+try:
+    stdout_bytes = wrap(sys.stdout.buffer, indirect=lambda: sys.stdout.buffer)
+except TypeError:
+    stdout_bytes = None
+try:
+    stderr_bytes = wrap(sys.stderr.buffer, indirect=lambda: sys.stderr.buffer)
+except TypeError:
+    stderr_bytes = None

--- a/src/aiofiles/threadpool/binary.py
+++ b/src/aiofiles/threadpool/binary.py
@@ -1,4 +1,4 @@
-from ..base import AsyncBase
+from ..base import AsyncBase, AsyncIndirectBase
 from .utils import (
     delegate_to_executor,
     proxy_method_directly,
@@ -26,7 +26,7 @@ from .utils import (
 @proxy_method_directly("detach", "fileno", "readable")
 @proxy_property_directly("closed", "raw", "name", "mode")
 class AsyncBufferedIOBase(AsyncBase):
-    """The asyncio executor version of io.BufferedWriter."""
+    """The asyncio executor version of io.BufferedWriter and BufferedIOBase."""
 
 
 @delegate_to_executor("peek")
@@ -55,3 +55,54 @@ class AsyncBufferedReader(AsyncBufferedIOBase):
 @proxy_property_directly("closed", "name", "mode")
 class AsyncFileIO(AsyncBase):
     """The asyncio executor version of io.FileIO."""
+
+
+@delegate_to_executor(
+    "close",
+    "flush",
+    "isatty",
+    "read",
+    "read1",
+    "readinto",
+    "readline",
+    "readlines",
+    "seek",
+    "seekable",
+    "tell",
+    "truncate",
+    "writable",
+    "write",
+    "writelines",
+)
+@proxy_method_directly("detach", "fileno", "readable")
+@proxy_property_directly("closed", "raw", "name", "mode")
+class AsyncIndirectBufferedIOBase(AsyncIndirectBase):
+    """The indirect asyncio executor version of io.BufferedWriter and BufferedIOBase."""
+
+
+@delegate_to_executor("peek")
+class AsyncIndirectBufferedReader(AsyncIndirectBufferedIOBase):
+    """The indirect asyncio executor version of io.BufferedReader and Random."""
+
+
+@delegate_to_executor(
+    "close",
+    "flush",
+    "isatty",
+    "read",
+    "readall",
+    "readinto",
+    "readline",
+    "readlines",
+    "seek",
+    "seekable",
+    "tell",
+    "truncate",
+    "writable",
+    "write",
+    "writelines",
+)
+@proxy_method_directly("fileno", "readable")
+@proxy_property_directly("closed", "name", "mode")
+class AsyncIndirectFileIO(AsyncIndirectBase):
+    """The indirect asyncio executor version of io.FileIO."""

--- a/src/aiofiles/threadpool/text.py
+++ b/src/aiofiles/threadpool/text.py
@@ -1,4 +1,4 @@
-from ..base import AsyncBase
+from ..base import AsyncBase, AsyncIndirectBase
 from .utils import (
     delegate_to_executor,
     proxy_method_directly,
@@ -35,3 +35,34 @@ from .utils import (
 )
 class AsyncTextIOWrapper(AsyncBase):
     """The asyncio executor version of io.TextIOWrapper."""
+
+
+@delegate_to_executor(
+    "close",
+    "flush",
+    "isatty",
+    "read",
+    "readable",
+    "readline",
+    "readlines",
+    "seek",
+    "seekable",
+    "tell",
+    "truncate",
+    "write",
+    "writable",
+    "writelines",
+)
+@proxy_method_directly("detach", "fileno", "readable")
+@proxy_property_directly(
+    "buffer",
+    "closed",
+    "encoding",
+    "errors",
+    "line_buffering",
+    "newlines",
+    "name",
+    "mode",
+)
+class AsyncTextIndirectIOWrapper(AsyncIndirectBase):
+    """The indirect asyncio executor version of io.TextIOWrapper."""

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -75,9 +75,9 @@ async def test_renames():
     assert exists(old_filename) is False and exists(new_filename)
     await aiofiles.os.renames(new_filename, old_filename)
     assert (
-        exists(old_filename) and
-        exists(new_filename) is False and
-        exists(dirname(new_filename)) is False
+        exists(old_filename)
+        and exists(new_filename) is False
+        and exists(dirname(new_filename)) is False
     )
 
 
@@ -323,6 +323,7 @@ async def test_listdir_dir_with_only_one_file():
     await aiofiles.os.remove(some_file)
     await aiofiles.os.rmdir(some_dir)
 
+
 @pytest.mark.asyncio
 async def test_listdir_dir_with_only_one_dir():
     """Test the listdir call when the dir has one dir."""
@@ -334,6 +335,7 @@ async def test_listdir_dir_with_only_one_dir():
     assert "other_dir" in dir_list
     await aiofiles.os.rmdir(other_dir)
     await aiofiles.os.rmdir(some_dir)
+
 
 @pytest.mark.asyncio
 async def test_listdir_dir_with_multiple_files():
@@ -352,6 +354,7 @@ async def test_listdir_dir_with_multiple_files():
     await aiofiles.os.remove(some_file)
     await aiofiles.os.remove(other_file)
     await aiofiles.os.rmdir(some_dir)
+
 
 @pytest.mark.asyncio
 async def test_listdir_dir_with_a_file_and_a_dir():
@@ -405,6 +408,7 @@ async def test_scandir_dir_with_only_one_file():
     assert some_file_entity.name == "some_file.txt"
     await aiofiles.os.remove(some_file)
     await aiofiles.os.rmdir(some_dir)
+
 
 @pytest.mark.asyncio
 async def test_scandir_dir_with_only_one_dir():

--- a/tests/test_stdio.py
+++ b/tests/test_stdio.py
@@ -1,6 +1,6 @@
 import sys
 import pytest
-from aiofiles import stdout, stderr, stdout_bytes, stderr_bytes
+from aiofiles import stdin, stdout, stderr, stdin_bytes, stdout_bytes, stderr_bytes
 
 
 @pytest.mark.asyncio
@@ -10,6 +10,8 @@ async def test_stdio(capsys):
     out, err = capsys.readouterr()
     assert out == "hello"
     assert err == "world"
+    with pytest.raises(OSError):
+        await stdin.read()
 
 
 @pytest.mark.asyncio
@@ -19,3 +21,5 @@ async def test_stdio_bytes(capsysbinary):
     out, err = capsysbinary.readouterr()
     assert out == b"hello"
     assert err == b"world"
+    with pytest.raises(OSError):
+        await stdin_bytes.read()

--- a/tests/test_stdio.py
+++ b/tests/test_stdio.py
@@ -1,0 +1,21 @@
+import sys
+import pytest
+from aiofiles import stdout, stderr, stdout_bytes, stderr_bytes
+
+
+@pytest.mark.asyncio
+async def test_stdio(capsys):
+    await stdout.write("hello")
+    await stderr.write("world")
+    out, err = capsys.readouterr()
+    assert out == "hello"
+    assert err == "world"
+
+
+@pytest.mark.asyncio
+async def test_stdio_bytes(capsysbinary):
+    await stdout_bytes.write(b"hello")
+    await stderr_bytes.write(b"world")
+    out, err = capsysbinary.readouterr()
+    assert out == b"hello"
+    assert err == b"world"

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -69,9 +69,9 @@ async def test_spooled_temporary_file(mode):
 @pytest.mark.skipif(
     sys.version_info < (3, 7),
     reason=(
-       "text-mode SpooledTemporaryFile is implemented with StringIO in py3.6"
-       "it doesn't support `newlines`"
-    )
+        "text-mode SpooledTemporaryFile is implemented with StringIO in py3.6"
+        "it doesn't support `newlines`"
+    ),
 )
 @pytest.mark.parametrize(
     "test_string, newlines", [("LF\n", "\n"), ("CRLF\r\n", "\r\n")]


### PR DESCRIPTION
Closes #153 
Closes #131 

This adds stdin, stdout, stderr, and their binary counterparts to aiofiles. It does this by introducing two concepts:

- that a file can be unattached from a loop and will instead look up the current loop for every operation. The performance impact of this is offset by the fact that for all previously supported uses of aiofiles, the only impact is a single `is None` check.
- that a file reference can be _indirect_, meaning it calls a getter to look it up for every operation. The performance impact of this is isolated to a new base class `AsyncIndirectBase`. This is only used when opted-in explicitly, which we do for the stdio files in order to support monkeypatching, as is common in the python ecosystem.