### PR TITLE
Fix __all__ on win32

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ async def test_stuff():
 
 ### History
 
+#### 23.2.2 (UNRELEASED)
+
+- Remove spurious items from `aiofiles.os.__all__` when running on Windows.
+
 #### 23.2.1 (2023-08-09)
 
 - Import `os.statvfs` conditionally to fix importing on non-UNIX systems.

--- a/src/aiofiles/os.py
+++ b/src/aiofiles/os.py
@@ -7,7 +7,6 @@ from .ospath import wrap
 __all__ = [
     "path",
     "stat",
-    "statvfs",
     "rename",
     "renames",
     "replace",
@@ -23,9 +22,12 @@ __all__ = [
     "listdir",
     "scandir",
     "access",
-    "sendfile",
     "wrap",
 ]
+if hasattr(os, "sendfile"):
+    __all__ += ["sendfile"]
+if hasattr(os, "statvfs"):
+    __all__ += ["statvfs"]
 
 
 stat = wrap(os.stat)


### PR DESCRIPTION
`sendfile` and `statvfs` are only defined when they are defined in the `os` module, i.e. not on win32. But they were added to `__all__` unconditionally.