### PR TITLE
Export the wrap function

### DIFF
--- a/src/aiofiles/__init__.py
+++ b/src/aiofiles/__init__.py
@@ -7,6 +7,7 @@ from .threadpool import (
     stdin_bytes,
     stdout_bytes,
     stderr_bytes,
+    wrap,
 )
 from . import tempfile
 
@@ -19,4 +20,5 @@ __all__ = [
     "stdin_bytes",
     "stdout_bytes",
     "stderr_bytes",
+    "wrap",
 ]

--- a/src/aiofiles/threadpool/__init__.py
+++ b/src/aiofiles/threadpool/__init__.py
@@ -31,6 +31,7 @@ __all__ = (
     "stdin_bytes",
     "stdout_bytes",
     "stderr_bytes",
+    "wrap",
 )
 
 


### PR DESCRIPTION
This allows e.g. (mostly) async usage of the `tarfile` module by manually wrapping the file objects that come out of it.