### PR TITLE
Add `to_agen` wrapper and `aiofiles.os.walk` and `aiofiles.os.fwalk`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 25.1.0 (2025-10-09)
 
+- Support asynchronous generators in the `wrap` generator
+  [#193](https://github.com/Tinche/aiofiles/pull/193)
 - Switch to [uv](https://docs.astral.sh/uv/) + add Python v3.14 support.
-  ([#219](https://github.com/Tinche/aiofiles/pull/219))
+  [#219](https://github.com/Tinche/aiofiles/pull/219)
 - Add `ruff` formatter and linter.
   [#216](https://github.com/Tinche/aiofiles/pull/216)
 - Drop Python 3.8 support. If you require it, use version 24.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 25.1.0 (2025-10-09)
 
-- Add asynchronous `to_agen` wrapper for synchronous iterators/generators -> add `os.fwalk` and `os.walk` async functions.
+- Add asynchronous `to_agen` wrapper for synchronous generators -> add `os.fwalk` (Linux only) and `os.walk`.
   [#193](https://github.com/Tinche/aiofiles/pull/193)
 - Switch to [uv](https://docs.astral.sh/uv/) + add Python v3.14 support.
   [#219](https://github.com/Tinche/aiofiles/pull/219)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 25.1.0 (2025-10-09)
 
-- Support asynchronous generators in the `wrap` generator
+- Add asynchronous `to_agen` wrapper for synchronous iterators/generators -> add `aiofiles.os.walk`.
   [#193](https://github.com/Tinche/aiofiles/pull/193)
 - Switch to [uv](https://docs.astral.sh/uv/) + add Python v3.14 support.
   [#219](https://github.com/Tinche/aiofiles/pull/219)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 25.1.0 (2025-10-09)
 
-- Add asynchronous `to_agen` wrapper for synchronous iterators/generators -> add `aiofiles.os.walk`.
+- Add asynchronous `to_agen` wrapper for synchronous iterators/generators -> add `os.fwalk` and `os.walk` async functions.
   [#193](https://github.com/Tinche/aiofiles/pull/193)
 - Switch to [uv](https://docs.astral.sh/uv/) + add Python v3.14 support.
   [#219](https://github.com/Tinche/aiofiles/pull/219)

--- a/Justfile
+++ b/Justfile
@@ -1,19 +1,19 @@
+src_dir := "src"
 tests_dir := "tests"
-code_dirs := "src" + " " + tests_dir
-run_prefix := if env_var_or_default("VIRTUAL_ENV", "") == "" { "uv run " } else { "" }
+code_dirs := src_dir + " " + tests_dir
 
 check:
-	{{ run_prefix }}ruff format --check {{ code_dirs }}
-	{{ run_prefix }}ruff check {{ code_dirs }}
+	ruff format --check {{ code_dirs }}
+	ruff check {{ code_dirs }}
 
 coverage:
-	{{ run_prefix }}coverage run -m pytest {{ tests_dir }}
+	coverage run -m pytest {{ tests_dir }}
 
-format:
-	{{ run_prefix }}ruff format {{ code_dirs }}
+fmt:
+	ruff format {{ code_dirs }}
 
-lint: format
-	{{ run_prefix }}ruff check --fix {{ code_dirs }}
+lint: fmt
+	ruff check --fix {{ code_dirs }}
 
 test:
-	{{ run_prefix }}pytest -x --ff {{ tests_dir }}
+	pytest {{ tests_dir }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,11 @@ source = [
 
 [tool.pytest.ini_options]
 minversion = "8.3"
+addopts = [
+    "-x",
+    "--ff",
+    "--maxfail=1"
+]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "coverage>=7.8.2",
     "pytest>=8.3.5",
     "pytest-asyncio>=1.0.0",
+    "pytest-random-order>=1.2.0",
 ]
 tox = [
     "tox>=4.26.0",
@@ -71,7 +72,8 @@ minversion = "8.3"
 addopts = [
     "-x",
     "--ff",
-    "--maxfail=1"
+    "--maxfail=1",
+    "--random-order",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ select = [
     "EM",  # flake8-errmsg (EM)
     "ERA",  # eradicate (ERA)
     "F",  # Pyflakes (F)
-    # "FBT",  # flake8-boolean-trap (FBT)
+    "FBT",  # flake8-boolean-trap (FBT)
     "I",  # isort (I)
     "ICN",  # flake8-import-conventions (ICN)
     "ISC",  # flake8-implicit-str-concat (ISC)

--- a/src/aiofiles/base.py
+++ b/src/aiofiles/base.py
@@ -1,18 +1,64 @@
-from asyncio import get_running_loop
-from collections.abc import Awaitable
+import asyncio
+import threading
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager
 from functools import partial, wraps
+from queue import Empty, Queue
 
 
-def wrap(func):
-    @wraps(func)
-    async def run(*args, loop=None, executor=None, **kwargs):
-        if loop is None:
-            loop = get_running_loop()
-        pfunc = partial(func, *args, **kwargs)
-        return await loop.run_in_executor(executor, pfunc)
+def to_agen(cb: Callable) -> Callable:
+    @wraps(cb)
+    async def _wrapper(*args, **kwargs) -> AsyncIterator:
+        def _iterate(
+            q: Queue, *, next_item_event: threading.Event, eoi_event: threading.Event
+        ):
+            try:
+                for row in cb(*args, **kwargs):
+                    # the event is cleared so that the iteration gets blocked
+                    # until the main generator allows the next iteration
+                    next_item_event.clear()
+                    q.put(row)
+                    next_item_event.wait()
+            finally:
+                eoi_event.set()  # end of iteration
 
-    return run
+        loop = asyncio.get_running_loop()
+        queue: Queue = Queue()  # thread-safe
+        ready_for_item = threading.Event()
+        end_of_iteration = threading.Event()
+        gen = partial(
+            _iterate,
+            q=queue,
+            next_item_event=ready_for_item,
+            eoi_event=end_of_iteration,
+        )
+        loop.run_in_executor(None, gen)
+
+        while True:
+            # in case the iterator is exhausted at this point
+            if end_of_iteration.is_set():
+                break
+            try:
+                # the `get_nowait` method is a remedy here
+                # because `queue.get()` could block the thread
+                # when queue is empty, but EOI was not set yet
+                item = queue.get_nowait()
+            except Empty:
+                continue
+            ready_for_item.set()
+            queue.task_done()
+            yield item
+        queue.join()
+
+    return _wrapper
+
+
+def wrap(cb: Callable) -> Callable:
+    @wraps(cb)
+    async def _wrapper(*args, **kwargs) -> Coroutine:
+        return await asyncio.to_thread(cb, *args, **kwargs)
+
+    return _wrapper
 
 
 class AsyncBase:
@@ -23,10 +69,9 @@ class AsyncBase:
 
     @property
     def _loop(self):
-        return self._ref_loop or get_running_loop()
+        return self._ref_loop or asyncio.get_running_loop()
 
     def __aiter__(self):
-        """We are our own iterator."""
         return self
 
     def __repr__(self):
@@ -73,7 +118,7 @@ class AiofilesContextManager(Awaitable, AbstractAsyncContextManager):
         return await self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await get_running_loop().run_in_executor(
+        await asyncio.get_running_loop().run_in_executor(
             None, self._obj._file.__exit__, exc_type, exc_val, exc_tb
         )
         self._obj = None

--- a/src/aiofiles/base.py
+++ b/src/aiofiles/base.py
@@ -3,7 +3,7 @@ import threading
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager
 from functools import partial, wraps
-from queue import Empty, Queue
+from queue import Queue
 from typing import Any
 
 
@@ -11,45 +11,33 @@ def to_agen(cb: Callable) -> Callable:
     @wraps(cb)
     async def _wrapper(*args, **kwargs) -> AsyncIterator:
         def _iterate(
-            q: Queue, *, next_item_event: threading.Event, eoi_event: threading.Event
+            q: Queue, *, next_item_event: threading.Event, eos_item: object
         ) -> None:
             try:
                 for row in cb(*args, **kwargs):
-                    # The `next_item_event` is cleared here
-                    # so that the current iteration will be blocked at the end
-                    # until the main generator allows the next iteration.
-                    # By this `yield-like` lazy behaviour is achieved
-                    # and the queue is filled successively and on-demand.
                     next_item_event.clear()
                     q.put(row)
                     next_item_event.wait()
             finally:
-                eoi_event.set()
+                q.put(eos_item)
 
         loop = asyncio.get_running_loop()
         queue: Queue = Queue()  # thread-safe
         ready_for_item = threading.Event()
-        end_of_iteration = threading.Event()
+        end_of_stream_item = object()
         gen = partial(
             _iterate,
             q=queue,
             next_item_event=ready_for_item,
-            eoi_event=end_of_iteration,
+            eos_item=end_of_stream_item,
         )
         loop.run_in_executor(None, gen)
 
         while True:
-            # In case the iterator is exhausted at the very beginning
-            if end_of_iteration.is_set():
+            item = queue.get()
+            if item is end_of_stream_item:
+                queue.task_done()
                 break
-            try:
-                # The `get_nowait` method is a remedy here
-                # because `queue.get()` could block the thread
-                # when queue is empty while EOI was not set.
-                # Playing with timeouts can also get the iteration stuck.
-                item = queue.get_nowait()
-            except Empty:
-                continue
             ready_for_item.set()
             queue.task_done()
             yield item

--- a/src/aiofiles/base.py
+++ b/src/aiofiles/base.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager
 from functools import partial, wraps
 from queue import Queue
-from typing import Any
+from typing import Any, Union
 
 
 def to_agen(cb: Callable) -> Callable:
@@ -13,13 +13,17 @@ def to_agen(cb: Callable) -> Callable:
         def _iterate(
             q: Queue, *, next_item_event: threading.Event, eos_item: object
         ) -> None:
+            nonlocal exc
             try:
                 for row in cb(*args, **kwargs):
                     next_item_event.clear()
                     q.put(row)
                     # Only the consumer can unblock the next iteration
                     next_item_event.wait()
+            except Exception as e:  # noqa: BLE001
+                exc = e
             finally:
+                # The End-Of-Stream entity must be put anyway
                 q.put(eos_item)
 
         loop = asyncio.get_running_loop()
@@ -34,6 +38,7 @@ def to_agen(cb: Callable) -> Callable:
         )
         loop.run_in_executor(None, gen)
 
+        exc: Union[None, Exception] = None
         while True:
             item = queue.get()
             queue.task_done()
@@ -42,6 +47,8 @@ def to_agen(cb: Callable) -> Callable:
             ready_for_item.set()
             yield item
         queue.join()
+        if exc:
+            raise exc
 
     return _wrapper
 

--- a/src/aiofiles/base.py
+++ b/src/aiofiles/base.py
@@ -1,9 +1,10 @@
 import asyncio
 import threading
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager
 from functools import partial, wraps
 from queue import Empty, Queue
+from typing import Any
 
 
 def to_agen(cb: Callable) -> Callable:
@@ -11,16 +12,19 @@ def to_agen(cb: Callable) -> Callable:
     async def _wrapper(*args, **kwargs) -> AsyncIterator:
         def _iterate(
             q: Queue, *, next_item_event: threading.Event, eoi_event: threading.Event
-        ):
+        ) -> None:
             try:
                 for row in cb(*args, **kwargs):
-                    # the event is cleared so that the iteration gets blocked
-                    # until the main generator allows the next iteration
+                    # The `next_item_event` is cleared here
+                    # so that the current iteration will be blocked at the end
+                    # until the main generator allows the next iteration.
+                    # By this `yield-like` lazy behaviour is achieved
+                    # and the queue is filled successively and on-demand.
                     next_item_event.clear()
                     q.put(row)
                     next_item_event.wait()
             finally:
-                eoi_event.set()  # end of iteration
+                eoi_event.set()
 
         loop = asyncio.get_running_loop()
         queue: Queue = Queue()  # thread-safe
@@ -35,13 +39,14 @@ def to_agen(cb: Callable) -> Callable:
         loop.run_in_executor(None, gen)
 
         while True:
-            # in case the iterator is exhausted at this point
+            # In case the iterator is exhausted at the very beginning
             if end_of_iteration.is_set():
                 break
             try:
-                # the `get_nowait` method is a remedy here
+                # The `get_nowait` method is a remedy here
                 # because `queue.get()` could block the thread
-                # when queue is empty, but EOI was not set yet
+                # when queue is empty while EOI was not set.
+                # Playing with timeouts can also get the iteration stuck.
                 item = queue.get_nowait()
             except Empty:
                 continue
@@ -55,7 +60,7 @@ def to_agen(cb: Callable) -> Callable:
 
 def wrap(cb: Callable) -> Callable:
     @wraps(cb)
-    async def _wrapper(*args, **kwargs) -> Coroutine:
+    async def _wrapper(*args, **kwargs) -> Any:
         return await asyncio.to_thread(cb, *args, **kwargs)
 
     return _wrapper

--- a/src/aiofiles/base.py
+++ b/src/aiofiles/base.py
@@ -17,6 +17,7 @@ def to_agen(cb: Callable) -> Callable:
                 for row in cb(*args, **kwargs):
                     next_item_event.clear()
                     q.put(row)
+                    # Only the consumer can unblock the next iteration
                     next_item_event.wait()
             finally:
                 q.put(eos_item)
@@ -24,7 +25,7 @@ def to_agen(cb: Callable) -> Callable:
         loop = asyncio.get_running_loop()
         queue: Queue = Queue()  # thread-safe
         ready_for_item = threading.Event()
-        end_of_stream_item = object()
+        end_of_stream_item = object()  # sentinel value
         gen = partial(
             _iterate,
             q=queue,
@@ -35,11 +36,10 @@ def to_agen(cb: Callable) -> Callable:
 
         while True:
             item = queue.get()
+            queue.task_done()
             if item is end_of_stream_item:
-                queue.task_done()
                 break
             ready_for_item.set()
-            queue.task_done()
             yield item
         queue.join()
 

--- a/src/aiofiles/os.py
+++ b/src/aiofiles/os.py
@@ -1,40 +1,36 @@
-"""Async executor versions of file functions from the os module."""
+"""Asynchronous version of the os module."""
 
 import os
 
 from . import ospath as path
-from .base import wrap
+from .base import to_agen, wrap
 
 __all__ = [
-    "path",
-    "stat",
+    "access",
+    "getcwd",
+    "listdir",
+    "makedirs",
+    "mkdir",
+    "readlink",
+    "remove",
+    "removedirs",
     "rename",
     "renames",
     "replace",
-    "remove",
-    "unlink",
-    "mkdir",
-    "makedirs",
     "rmdir",
-    "removedirs",
-    "symlink",
-    "readlink",
-    "listdir",
+    "path",
     "scandir",
-    "access",
-    "wrap",
-    "getcwd",
+    "stat",
+    "symlink",
+    "unlink",
+    "walk",
 ]
 
 access = wrap(os.access)
-
 getcwd = wrap(os.getcwd)
-
 listdir = wrap(os.listdir)
-
 makedirs = wrap(os.makedirs)
 mkdir = wrap(os.mkdir)
-
 readlink = wrap(os.readlink)
 remove = wrap(os.remove)
 removedirs = wrap(os.removedirs)
@@ -42,12 +38,14 @@ rename = wrap(os.rename)
 renames = wrap(os.renames)
 replace = wrap(os.replace)
 rmdir = wrap(os.rmdir)
-
 scandir = wrap(os.scandir)
 stat = wrap(os.stat)
 symlink = wrap(os.symlink)
-
 unlink = wrap(os.unlink)
+# In Python 3.9:
+# 1. `inspect.isgeneratorfunction(os.walk)` is False
+# 2. `inspect.isfunction(os.walk)` is True
+walk = to_agen(os.walk)
 
 
 if hasattr(os, "link"):

--- a/src/aiofiles/os.py
+++ b/src/aiofiles/os.py
@@ -7,7 +7,6 @@ from .base import to_agen, wrap
 
 __all__ = [
     "access",
-    "fwalk",
     "getcwd",
     "listdir",
     "makedirs",
@@ -28,7 +27,6 @@ __all__ = [
 ]
 
 access = wrap(os.access)
-fwalk = to_agen(os.fwalk)
 getcwd = wrap(os.getcwd)
 listdir = wrap(os.listdir)
 makedirs = wrap(os.makedirs)
@@ -47,6 +45,9 @@ unlink = wrap(os.unlink)
 walk = to_agen(os.walk)
 
 
+if hasattr(os, "link"):
+    __all__ += ["fwalk"]
+    fwalk = to_agen(os.fwalk)
 if hasattr(os, "link"):
     __all__ += ["link"]
     link = wrap(os.link)

--- a/src/aiofiles/os.py
+++ b/src/aiofiles/os.py
@@ -45,7 +45,7 @@ unlink = wrap(os.unlink)
 walk = to_agen(os.walk)
 
 
-if hasattr(os, "link"):
+if hasattr(os, "fwalk"):
     __all__ += ["fwalk"]
     fwalk = to_agen(os.fwalk)
 if hasattr(os, "link"):

--- a/src/aiofiles/os.py
+++ b/src/aiofiles/os.py
@@ -7,6 +7,7 @@ from .base import to_agen, wrap
 
 __all__ = [
     "access",
+    "fwalk",
     "getcwd",
     "listdir",
     "makedirs",
@@ -27,6 +28,7 @@ __all__ = [
 ]
 
 access = wrap(os.access)
+fwalk = to_agen(os.fwalk)
 getcwd = wrap(os.getcwd)
 listdir = wrap(os.listdir)
 makedirs = wrap(os.makedirs)
@@ -42,9 +44,6 @@ scandir = wrap(os.scandir)
 stat = wrap(os.stat)
 symlink = wrap(os.symlink)
 unlink = wrap(os.unlink)
-# In Python 3.9:
-# 1. `inspect.isgeneratorfunction(os.walk)` is False
-# 2. `inspect.isfunction(os.walk)` is True
 walk = to_agen(os.walk)
 
 

--- a/src/aiofiles/ospath.py
+++ b/src/aiofiles/ospath.py
@@ -1,4 +1,4 @@
-"""Async executor versions of file functions from the os.path module."""
+"""Asynchronous version of the os.path module."""
 
 from os import path
 
@@ -20,18 +20,14 @@ __all__ = [
 ]
 
 abspath = wrap(path.abspath)
-
 getatime = wrap(path.getatime)
 getctime = wrap(path.getctime)
 getmtime = wrap(path.getmtime)
 getsize = wrap(path.getsize)
-
 exists = wrap(path.exists)
-
 isdir = wrap(path.isdir)
 isfile = wrap(path.isfile)
 islink = wrap(path.islink)
 ismount = wrap(path.ismount)
-
 samefile = wrap(path.samefile)
 sameopenfile = wrap(path.sameopenfile)

--- a/src/aiofiles/tempfile/__init__.py
+++ b/src/aiofiles/tempfile/__init__.py
@@ -35,8 +35,8 @@ if sys.version_info >= (3, 12):
         suffix=None,
         prefix=None,
         dir=None,
-        delete=True,
-        delete_on_close=True,
+        delete=True,  # noqa: FBT002
+        delete_on_close=True,  # noqa: FBT002
         loop=None,
         executor=None,
     ):
@@ -68,7 +68,7 @@ else:
         suffix=None,
         prefix=None,
         dir=None,
-        delete=True,
+        delete=True,  # noqa: FBT002
         loop=None,
         executor=None,
     ):
@@ -162,7 +162,7 @@ def TemporaryDirectory(suffix=None, prefix=None, dir=None, loop=None, executor=N
 if sys.version_info >= (3, 12):
 
     async def _temporary_file(
-        named=True,
+        named=True,  # noqa: FBT002
         mode="w+b",
         buffering=-1,
         encoding=None,
@@ -170,8 +170,8 @@ if sys.version_info >= (3, 12):
         suffix=None,
         prefix=None,
         dir=None,
-        delete=True,
-        delete_on_close=True,
+        delete=True,  # noqa: FBT002
+        delete_on_close=True,  # noqa: FBT002
         loop=None,
         executor=None,
         max_size=0,
@@ -219,7 +219,7 @@ if sys.version_info >= (3, 12):
 else:
 
     async def _temporary_file(
-        named=True,
+        named=True,  # noqa: FBT002
         mode="w+b",
         buffering=-1,
         encoding=None,
@@ -227,7 +227,7 @@ else:
         suffix=None,
         prefix=None,
         dir=None,
-        delete=True,
+        delete=True,  # noqa: FBT002
         loop=None,
         executor=None,
         max_size=0,

--- a/src/aiofiles/threadpool/__init__.py
+++ b/src/aiofiles/threadpool/__init__.py
@@ -41,7 +41,7 @@ def open(
     encoding=None,
     errors=None,
     newline=None,
-    closefd=True,
+    closefd=True,  # noqa: FBT002
     opener=None,
     *,
     loop=None,
@@ -70,7 +70,7 @@ async def _open(
     encoding=None,
     errors=None,
     newline=None,
-    closefd=True,
+    closefd=True,  # noqa: FBT002
     opener=None,
     *,
     loop=None,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -92,15 +92,22 @@ class TestToAsyncGeneratorWrapper:
             assert lc == results[idx]
             assert lc not in accumulator
 
-    async def test_reusability(self) -> None:
+    async def test_aiter_exhaustion(self) -> None:
+        adoiter = to_agen(self._doiter)
+        seq = [None, object(), Exception()]
+        agen = adoiter(seq)
+        assert [i async for i in agen] == seq
+        assert [i async for i in agen] == []
+
+    async def test_same_aiter_multiple_calls(self) -> None:
         adoiter = to_agen(self._doiter)
         seq = [None, object(), Exception()]
         for _ in range(2):
             assert [i async for i in adoiter(seq)] == seq
 
-    async def test_exception(self) -> None:
+    async def test_exception_raised(self) -> None:
         adoiter = to_agen(self._doiter)
-        seq = [3, 2, 1, ZeroDivisionError("zero")]
+        seq = [3, 2, 1, ZeroDivisionError("zero"), -1]
         res: Union[None, list] = None
         with pytest.raises(ZeroDivisionError):
             res = [i async for i in adoiter(seq, raise_if_exception=True)]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -52,7 +52,7 @@ class TestToAsyncGeneratorWrapper:
         elapsed = time.time() - start
         result: str = "".join(accumulator)
 
-        assert max(word_lengths) * timeout < elapsed < sum(word_lengths) * timeout * 2
+        assert max(word_lengths) * timeout < elapsed < sum(word_lengths) * timeout * 3
         assert set(results) == set(words)
 
         for word in words:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,84 @@
+import asyncio
+import time
+from collections.abc import AsyncIterable, Generator, Iterable
+from typing import Any
+
+from aiofiles.base import to_agen, wrap
+
+
+class TestToAsyncGeneratorWrapper:
+    """Test suite for the `to_agen` decorator."""
+
+    def _iter_io(
+        self, it: Iterable, *, with_timeout: float = 1.0, with_result: Any = 42
+    ) -> Generator[Any, None, None]:
+        for item in it:
+            time.sleep(with_timeout)
+            yield item
+        return with_result
+
+    async def _do_aiter(
+        self, ait: AsyncIterable[str], *, acc: list[str], lock: asyncio.Lock
+    ) -> str:
+        letters: list[str] = []
+        async for item in ait:
+            async with lock:
+                letters.append(item)
+                acc.append(item)
+            # `async for` does not responsible for coroutine switching
+            # so we need to yield control back to the event loop
+            await asyncio.sleep(0)
+        return "".join(letters)
+
+    async def test_to_agen(self) -> None:
+        lock = asyncio.Lock()
+        timeout: float = 0.01
+        words: list[str] = ["Hello", "Aiofiles"]
+        word_lengths: list[int] = [len(word) for word in words]
+        accumulator: list[str] = []
+        tasks: list[asyncio.Task] = []
+
+        start = time.time()
+        for word in words:
+            task = asyncio.create_task(
+                self._do_aiter(
+                    to_agen(self._iter_io)(word, with_timeout=timeout),
+                    acc=accumulator,
+                    lock=lock,
+                )
+            )
+            tasks.append(task)
+        results = await asyncio.gather(*tasks)
+        elapsed = time.time() - start
+        result: str = "".join(accumulator)
+
+        assert max(word_lengths) * timeout < elapsed < sum(word_lengths) * timeout * 2
+        assert set(results) == set(words)
+
+        for word in words:
+            # testing non-sequential ordering
+            assert word not in result
+
+
+class TestToCoroutineWrapper:
+    """Test suite for the wrap decorator."""
+
+    def _do_io(self, *, with_timeout: float = 1.0, with_result: Any = 42) -> Any:
+        time.sleep(with_timeout)
+        return with_result
+
+    async def test_wrap(self) -> None:
+        tasks: list[asyncio.Task] = []
+        seconds = list(range(1, 11))
+
+        start = time.time()
+        for second in seconds:
+            task = asyncio.create_task(
+                wrap(self._do_io)(with_timeout=second / 10, with_result=second)
+            )
+            tasks.append(task)
+        results = await asyncio.gather(*tasks)
+        elapsed = time.time() - start
+
+        assert 0.1 < elapsed < 2  # 2 will do
+        assert all(result == answer for result, answer in zip(results, seconds))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from collections.abc import AsyncIterable, Iterable, Sequence
-from typing import Any
+from typing import Any, Union
 
 import pytest
 
@@ -11,10 +11,19 @@ from aiofiles.base import to_agen, wrap
 class TestToAsyncGeneratorWrapper:
     """Test suite for the `to_agen` decorator."""
 
-    def _doiter(self, data: Iterable, *, with_timeout: float = 0.001):
+    def _doiter(
+        self,
+        data: Iterable,
+        *,
+        with_timeout: float = 0.001,
+        raise_if_exception: bool = False,
+    ):
         for datum in data:
+            if raise_if_exception and isinstance(datum, Exception):
+                raise datum
             time.sleep(with_timeout)
             yield datum
+        return 42
 
     @pytest.mark.parametrize(
         "seq",
@@ -88,6 +97,14 @@ class TestToAsyncGeneratorWrapper:
         seq = [None, object(), Exception()]
         for _ in range(2):
             assert [i async for i in adoiter(seq)] == seq
+
+    async def test_exception(self) -> None:
+        adoiter = to_agen(self._doiter)
+        seq = [3, 2, 1, ZeroDivisionError("zero")]
+        res: Union[None, list] = None
+        with pytest.raises(ZeroDivisionError):
+            res = [i async for i in adoiter(seq, raise_if_exception=True)]
+        assert res is None
 
 
 class TestToCoroutineWrapper:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -44,7 +44,7 @@ class TestToAsyncGeneratorWrapper:
             ],
         ],
     )
-    async def test_to_agen(self, seq: Sequence) -> None:
+    async def test_basic_iterations(self, seq: Sequence) -> None:
         adoiter = to_agen(self._doiter)
         assert [i async for i in adoiter(seq)] == list(seq)
 
@@ -61,7 +61,7 @@ class TestToAsyncGeneratorWrapper:
             await asyncio.sleep(0)
         return items
 
-    async def test_to_agen_non_sequential(self) -> None:
+    async def test_non_sequential_execution(self) -> None:
         lock = asyncio.Lock()
         collections: list[Sequence] = ["Aiofiles", tuple("Rocks"), [42, 21]]
         accumulator: list[str] = []
@@ -82,6 +82,12 @@ class TestToAsyncGeneratorWrapper:
             lc = list(collection)
             assert lc == results[idx]
             assert lc not in accumulator
+
+    async def test_reusability(self) -> None:
+        adoiter = to_agen(self._doiter)
+        seq = [None, object(), Exception()]
+        for _ in range(2):
+            assert [i async for i in adoiter(seq)] == seq
 
 
 class TestToCoroutineWrapper:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,9 @@
 import asyncio
 import time
-from collections.abc import AsyncIterable, Generator, Iterable
+from collections.abc import AsyncIterable, Iterable, Sequence
 from typing import Any
+
+import pytest
 
 from aiofiles.base import to_agen, wrap
 
@@ -9,76 +11,99 @@ from aiofiles.base import to_agen, wrap
 class TestToAsyncGeneratorWrapper:
     """Test suite for the `to_agen` decorator."""
 
-    def _iter_io(
-        self, it: Iterable, *, with_timeout: float = 1.0, with_result: Any = 42
-    ) -> Generator[Any, None, None]:
-        for item in it:
+    def _doiter(self, data: Iterable, *, with_timeout: float = 0.001):
+        for datum in data:
             time.sleep(with_timeout)
-            yield item
-        return with_result
+            yield datum
+
+    @pytest.mark.parametrize(
+        "seq",
+        [
+            "",
+            "A",
+            "AB",
+            "ABC",
+            [1, 2, [3, 4]],
+            [None, None, None],
+            [Exception(), ValueError(), TypeError(), BaseException()],
+            [object(), object()],
+            [
+                1,
+                [2],
+                None,
+                {3},
+                Exception(),
+                {"a": "b"},
+                "str",
+                object(),
+                None,
+                BaseException(),
+                object(),
+                None,
+                object(),
+            ],
+        ],
+    )
+    async def test_to_agen(self, seq: Sequence) -> None:
+        adoiter = to_agen(self._doiter)
+        assert [i async for i in adoiter(seq)] == list(seq)
 
     async def _do_aiter(
-        self, ait: AsyncIterable[str], *, acc: list[str], lock: asyncio.Lock
-    ) -> str:
-        letters: list[str] = []
+        self, ait: AsyncIterable, *, global_acc: list, lock: asyncio.Lock
+    ) -> list:
+        items: list = []
         async for item in ait:
             async with lock:
-                letters.append(item)
-                acc.append(item)
+                items.append(item)
+                global_acc.append(item)
             # `async for` does not responsible for coroutine switching
             # so we need to yield control back to the event loop
             await asyncio.sleep(0)
-        return "".join(letters)
+        return items
 
-    async def test_to_agen(self) -> None:
+    async def test_to_agen_non_sequential(self) -> None:
         lock = asyncio.Lock()
-        timeout: float = 0.01
-        words: list[str] = ["Hello", "Aiofiles"]
-        word_lengths: list[int] = [len(word) for word in words]
+        collections: list[Sequence] = ["Aiofiles", tuple("Rocks"), [42, 21]]
         accumulator: list[str] = []
         tasks: list[asyncio.Task] = []
 
-        start = time.time()
-        for word in words:
+        for collection in collections:
             task = asyncio.create_task(
                 self._do_aiter(
-                    to_agen(self._iter_io)(word, with_timeout=timeout),
-                    acc=accumulator,
+                    to_agen(self._doiter)(collection),
+                    global_acc=accumulator,
                     lock=lock,
                 )
             )
             tasks.append(task)
         results = await asyncio.gather(*tasks)
-        elapsed = time.time() - start
-        result: str = "".join(accumulator)
 
-        assert max(word_lengths) * timeout < elapsed < sum(word_lengths) * timeout * 3
-        assert set(results) == set(words)
-
-        for word in words:
-            # testing non-sequential ordering
-            assert word not in result
+        for idx, collection in enumerate(collections):
+            lc = list(collection)
+            assert lc == results[idx]
+            assert lc not in accumulator
 
 
 class TestToCoroutineWrapper:
     """Test suite for the wrap decorator."""
 
-    def _do_io(self, *, with_timeout: float = 1.0, with_result: Any = 42) -> Any:
+    def _do_io(self, *, with_timeout: float = 0.001, with_result: Any = 42) -> Any:
         time.sleep(with_timeout)
         return with_result
 
     async def test_wrap(self) -> None:
         tasks: list[asyncio.Task] = []
         seconds = list(range(1, 11))
+        time_coef = 0.001
 
         start = time.time()
         for second in seconds:
             task = asyncio.create_task(
-                wrap(self._do_io)(with_timeout=second / 10, with_result=second)
+                wrap(self._do_io)(with_timeout=time_coef * second, with_result=second)
             )
             tasks.append(task)
         results = await asyncio.gather(*tasks)
         elapsed = time.time() - start
 
-        assert 0.1 < elapsed < 2  # 2 will do
+        assert seconds[0] * time_coef < elapsed < seconds[0]
         assert all(result == answer for result, answer in zip(results, seconds))

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -3,9 +3,11 @@
 import asyncio
 import os
 import platform
+from collections import defaultdict
 from os import stat
 from os.path import dirname, exists, isdir, join
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -498,3 +500,74 @@ async def test_abspath():
     abs_filename = join(dirname(__file__), "resources", "test_file1.txt")
     result = await aiofiles.os.path.abspath(relative_filename)
     assert result == abs_filename
+
+
+def _act_on_error(oserror):
+    print(f"aiofiles.os.walk onerror handler: {oserror}")
+
+
+@pytest.mark.parametrize(
+    ("top", "topdown", "onerror", "followlinks"),
+    [
+        ("non-existent", True, _act_on_error, False),
+        ("README.md", True, None, False),
+        ("README.md", False, _act_on_error, False),
+        ("./src", True, _act_on_error, False),
+        ("./src", False, _act_on_error, False),
+        ("./tests", True, None, True),
+        ("./tests", False, None, True),
+    ],
+)
+async def test_walk(top, topdown, onerror, followlinks):
+    result = [  # noqa: C416
+        row
+        async for row in aiofiles.os.walk(
+            top=top, topdown=topdown, onerror=onerror, followlinks=followlinks
+        )
+    ]
+    answer = list(
+        os.walk(top=top, topdown=topdown, onerror=onerror, followlinks=followlinks)
+    )
+
+    assert result == answer
+
+
+@pytest.mark.parametrize(
+    "top_path",
+    [
+        "c3Po-ar2D2",  # does not mean to exist
+        "./.github",
+        "./src",
+        "./tests",
+        # ".",  # it can take too long
+    ],
+)
+async def test_walk_non_blocking(top_path: str):
+    async def _test_walk(
+        top: str, key: str, storage: defaultdict[str, list]
+    ) -> Optional[bool]:
+        non_blocking = None
+        async for datum in aiofiles.os.walk(top=top):
+            storage[key].append(datum)
+            # checking the statistics (common shareable resource) for other tasks
+            other_keys = set(storage) - {key}
+            if not non_blocking:
+                non_blocking = any(storage[other_key] for other_key in other_keys)
+            # without the `asyncio.sleep(0)` the `async for` may block
+            await asyncio.sleep(0)
+
+        return non_blocking
+
+    keys = {f"w_{i}" for i in range(2)}
+    storage = defaultdict(list)
+
+    tasks: list[asyncio.Task] = [
+        asyncio.create_task(_test_walk(top=top_path, key=key, storage=storage))
+        for key in keys
+    ]
+    results = await asyncio.gather(*tasks)
+
+    # Asserting that each task does not block the event loop.
+    # Empty results are not assumed to be non-blocking by default.
+    if statuses := (r for r in results if r is not None):
+        assert all(statuses)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -504,7 +504,6 @@ async def test_abspath():
 
 
 class TestWalkGenerators:
-    @pytest.mark.skipif(platform.system() == "Windows", reason="Doesn't work on Win")
     @pytest.mark.parametrize(
         ("top", "topdown", "onerror", "follow_symlinks"),
         [
@@ -524,6 +523,7 @@ class TestWalkGenerators:
             ("./tests", False, None, True),
         ],
     )
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Doesn't work on Win")
     async def test_fwalk(
         self, top: str, topdown: bool, onerror: Callable, follow_symlinks: bool
     ) -> None:

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import platform
 from collections import defaultdict
+from collections.abc import Callable
 from os import stat
 from os.path import dirname, exists, isdir, join
 from pathlib import Path
@@ -502,72 +503,80 @@ async def test_abspath():
     assert result == abs_filename
 
 
-def _act_on_error(oserror):
-    print(f"aiofiles.os.walk onerror handler: {oserror}")
-
-
-@pytest.mark.parametrize(
-    ("top", "topdown", "onerror", "followlinks"),
-    [
-        ("non-existent", True, _act_on_error, False),
-        ("README.md", True, None, False),
-        ("README.md", False, _act_on_error, False),
-        ("./src", True, _act_on_error, False),
-        ("./src", False, _act_on_error, False),
-        ("./tests", True, None, True),
-        ("./tests", False, None, True),
-    ],
-)
-async def test_walk(top, topdown, onerror, followlinks):
-    result = [  # noqa: C416
-        row
-        async for row in aiofiles.os.walk(
-            top=top, topdown=topdown, onerror=onerror, followlinks=followlinks
-        )
-    ]
-    answer = list(
-        os.walk(top=top, topdown=topdown, onerror=onerror, followlinks=followlinks)
+class TestWalk:
+    @pytest.mark.parametrize(
+        ("top", "topdown", "onerror", "followlinks"),
+        [
+            (
+                "non-existent",
+                True,
+                lambda oserror: print(f"aiofiles.os.walk onerror handler: {oserror}"),
+                False,
+            ),
+            ("README.md", True, None, False),
+            ("README.md", False, lambda x: x, False),
+            ("./src", True, lambda t: str(t), False),
+            (
+                "./src",
+                False,
+                lambda oserror: print(f"aiofiles.os.walk onerror handler: {oserror}"),
+                False,
+            ),
+            ("./tests", True, None, True),
+            ("./tests", False, None, True),
+        ],
     )
+    async def test_walk(
+        self, top: str, topdown: bool, onerror: Callable, followlinks: bool
+    ) -> None:
+        result = [  # noqa: C416
+            row
+            async for row in aiofiles.os.walk(
+                top=top, topdown=topdown, onerror=onerror, followlinks=followlinks
+            )
+        ]
+        answer = list(
+            os.walk(top=top, topdown=topdown, onerror=onerror, followlinks=followlinks)
+        )
 
-    assert result == answer
+        assert result == answer
 
+    @pytest.mark.parametrize(
+        "top_path",
+        [
+            "c3Po-ar2D2",  # does not mean to exist
+            "./.github",
+            "./src",
+            "./tests",
+            # ".",  # it can take too long
+        ],
+    )
+    async def test_walk_non_blocking(self, top_path: str) -> None:
+        async def _test_walk(
+            top: str, key: str, storage: defaultdict[str, list]
+        ) -> Optional[bool]:
+            non_blocking = None
+            async for datum in aiofiles.os.walk(top=top):
+                storage[key].append(datum)
+                # checking the statistics (common shareable resource) for other tasks
+                other_keys = set(storage) - {key}
+                if not non_blocking:
+                    non_blocking = any(storage[other_key] for other_key in other_keys)
+                # without the `asyncio.sleep(0)` the `async for` may block
+                await asyncio.sleep(0)
 
-@pytest.mark.parametrize(
-    "top_path",
-    [
-        "c3Po-ar2D2",  # does not mean to exist
-        "./.github",
-        "./src",
-        "./tests",
-        # ".",  # it can take too long
-    ],
-)
-async def test_walk_non_blocking(top_path: str):
-    async def _test_walk(
-        top: str, key: str, storage: defaultdict[str, list]
-    ) -> Optional[bool]:
-        non_blocking = None
-        async for datum in aiofiles.os.walk(top=top):
-            storage[key].append(datum)
-            # checking the statistics (common shareable resource) for other tasks
-            other_keys = set(storage) - {key}
-            if not non_blocking:
-                non_blocking = any(storage[other_key] for other_key in other_keys)
-            # without the `asyncio.sleep(0)` the `async for` may block
-            await asyncio.sleep(0)
+            return non_blocking
 
-        return non_blocking
+        keys = {f"w_{i}" for i in range(2)}
+        storage = defaultdict(list)
 
-    keys = {f"w_{i}" for i in range(2)}
-    storage = defaultdict(list)
+        tasks: list[asyncio.Task] = [
+            asyncio.create_task(_test_walk(top=top_path, key=key, storage=storage))
+            for key in keys
+        ]
+        results = await asyncio.gather(*tasks)
 
-    tasks: list[asyncio.Task] = [
-        asyncio.create_task(_test_walk(top=top_path, key=key, storage=storage))
-        for key in keys
-    ]
-    results = await asyncio.gather(*tasks)
-
-    # Asserting that each task does not block the event loop.
-    # Empty results are not assumed to be non-blocking by default.
-    if statuses := (r for r in results if r is not None):
-        assert all(statuses)
+        # Asserting that each task does not block the event loop.
+        # Empty results are not assumed to be non-blocking by default.
+        if statuses := (r for r in results if r is not None):
+            assert all(statuses)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -504,6 +504,7 @@ async def test_abspath():
 
 
 class TestWalkGenerators:
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Doesn't work on Win")
     @pytest.mark.parametrize(
         ("top", "topdown", "onerror", "follow_symlinks"),
         [

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -525,7 +525,11 @@ class TestWalkGenerators:
     )
     @pytest.mark.skipif(platform.system() == "Windows", reason="Doesn't work on Win")
     async def test_fwalk(
-        self, top: str, topdown: bool, onerror: Callable, follow_symlinks: bool
+        self,
+        top: str,
+        topdown: bool,  # noqa: FBT001
+        onerror: Callable,
+        follow_symlinks: bool,  # noqa: FBT001
     ) -> None:
         result = [  # noqa: C416
             row
@@ -569,7 +573,11 @@ class TestWalkGenerators:
         ],
     )
     async def test_walk(
-        self, top: str, topdown: bool, onerror: Callable, followlinks: bool
+        self,
+        top: str,
+        topdown: bool,  # noqa: FBT001
+        onerror: Callable,
+        followlinks: bool,  # noqa: FBT001
     ) -> None:
         result = [  # noqa: C416
             row

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -503,7 +503,48 @@ async def test_abspath():
     assert result == abs_filename
 
 
-class TestWalk:
+class TestWalkGenerators:
+    @pytest.mark.parametrize(
+        ("top", "topdown", "onerror", "follow_symlinks"),
+        [
+            (
+                "./src",
+                True,
+                lambda oserror: print(f"aiofiles.os.walk onerror handler: {oserror}"),
+                False,
+            ),
+            (
+                "./src",
+                False,
+                lambda oserror: print(f"aiofiles.os.walk onerror handler: {oserror}"),
+                False,
+            ),
+            ("./tests", True, None, True),
+            ("./tests", False, None, True),
+        ],
+    )
+    async def test_fwalk(
+        self, top: str, topdown: bool, onerror: Callable, follow_symlinks: bool
+    ) -> None:
+        result = [  # noqa: C416
+            row
+            async for row in aiofiles.os.fwalk(
+                top=top,
+                topdown=topdown,
+                onerror=onerror,
+                follow_symlinks=follow_symlinks,
+            )
+        ]
+        answer = list(
+            os.fwalk(
+                top=top,
+                topdown=topdown,
+                onerror=onerror,
+                follow_symlinks=follow_symlinks,
+            )
+        )
+        assert result == answer
+
     @pytest.mark.parametrize(
         ("top", "topdown", "onerror", "followlinks"),
         [
@@ -538,7 +579,6 @@ class TestWalk:
         answer = list(
             os.walk(top=top, topdown=topdown, onerror=onerror, followlinks=followlinks)
         )
-
         assert result == answer
 
     @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ test = [
     { name = "coverage" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-random-order" },
 ]
 tox = [
     { name = "tox" },
@@ -32,6 +33,7 @@ test = [
     { name = "coverage", specifier = ">=7.8.2" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
+    { name = "pytest-random-order", specifier = ">=1.2.0" },
 ]
 tox = [
     { name = "tox", specifier = ">=4.26.0" },
@@ -309,6 +311,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
+]
+
+[[package]]
+name = "pytest-random-order"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/ad/a2a32d91effe0f84a300b9ba6c9d000bd52f31b77f8e49d8fd8653a9ddc3/pytest_random_order-1.2.0.tar.gz", hash = "sha256:12b2d4ee977ec9922b5e3575afe13c22cbdb06e3d03e550abc43df137b90439a", size = 107304, upload-time = "2025-06-22T14:44:43.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/7f/92c8dbe185aa38270fec1e73e0ed70d8e5de31963aa057ba621055f8b008/pytest_random_order-1.2.0-py3-none-any.whl", hash = "sha256:78d1d6f346222cdf26a7302c502d2f1cab19454529af960b8b9e1427a99ab277", size = 10889, upload-time = "2025-06-22T14:44:42.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #160 .
Also may close #167 .
Potentially closes #207 .

Features:

- `to_agen` for wrapping synchronous generators;
- `wrap` uses asyncio.to_thread under the hood because Python3.9 is minimum version;
- the asynchronous versions of the `os.walk` and `os.fwalk` (Linux only) are added (`to_agen` made it possible)
- tests updated and test execution order is randomised for each run by default
- minor changes