### PR TITLE
Bump GHA artifact action from v3 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
           echo "total=$TOTAL" >> $GITHUB_ENV
 
       - name: "Upload HTML report."
-        uses: "actions/upload-artifact@v3"
+        uses: "actions/upload-artifact@v4"
         with:
           name: "html-report"
           path: "htmlcov"

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Packages
           path: dist
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Packages
           path: dist


### PR DESCRIPTION
Hello.

The version 3 is deprecated (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), so updated to the version 4.

Found in the #193 . Failed job ( https://github.com/Tinche/aiofiles/actions/runs/13090631124/job/36526912197 ).
